### PR TITLE
Enable a bunch of strictness checks in the TS compilation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,7 @@ gulp.task('accept-baselines', function () {
 // clean local test baselines
 gulp.task('clean-local-baselines', function (cb) {
 	del(["tests/baselines/local"])
-		.then(() => cb(), e => cb(e));
+		.then(function() { return cb() }, function(e) { return cb(e) });
 });
 
 // run tests

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var builder_1 = require('./builder');
 var fs_1 = require('fs');
 var path_1 = require('path');
 var utils_1 = require('./utils');
+require('es6-object-assign').polyfill();
 var IncrementalCompiler = (function () {
     function IncrementalCompiler() {
         throw new Error("Not implemented");

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "incremental"
   ],
   "dependencies": {
+    "es6-object-assign": "^1.0.2",
     "gulp-util": "^3.0.1",
+    "pinkie-promise": "^2.0.1",
     "through": "^2.3.6",
     "vinyl": "^0.4.3",
     "vinyl-fs": "^2.4.3"

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,7 +1,6 @@
 'use strict';
 
 import index = require('../index');
-import builder = require('../builder');
 import assert = require('assert');
 
 describe('options - test that', function () {

--- a/src/tests/scenarios.test.ts
+++ b/src/tests/scenarios.test.ts
@@ -27,7 +27,6 @@ describe("scenario", () => {
                     const relativedir = path.normalize(path.dirname(file.relative))
                         .replace(/([\\/])\.($|[\\/])/g, "$1dot$2")
                         .replace(/(^|[\\/])\.\.($|[\\/])/g, "$1dotDot$2");
-                    const relative = path.join(name, relativedir, basename);
                     files.push(path.normalize(path.join(relativedir, basename)));
                     participants.push(assert.baseline(file.contents, path.join(name, relativedir, basename), { base: baselinesdir }));
                     if (file.sourceMap) {
@@ -43,8 +42,16 @@ describe("scenario", () => {
                     if (ended) return;
                     ended = true;
                     participants.push(assert.baseline(normalizeLineEndings(JSON.stringify(files.sort(), undefined, "  ")), path.join(name, "files.json"), { base: baselinesdir }));
-                    const waitOne = () => participants.length ? participants.shift().then(waitOne, done) : done();
                     waitOne();
+
+                    function waitOne(): void {
+                        if (participants.length) {
+                            participants.shift()!.then(waitOne, done);
+                        }
+                        else {
+                            done();
+                        }
+                    }
                 }
             });
         }

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -4,65 +4,65 @@ import utils = require('../utils');
 import assert = require('assert');
 
 describe('graph - test that', function() {
-	
+
 	var graph:utils.graph.Graph<string>;
-	
+
 	beforeEach(function() {
 		graph = new utils.graph.Graph<string>(s => s);
 	});
-	
+
 	it('cannot be traversed when empty', function() {
 		graph.traverse('foo', true, () => assert.ok(false));
 		graph.traverse('foo', false, () => assert.ok(false));
 		assert.ok(true);
 	});
-	
+
 	it('is possible to lookup nodes that don\'t exist', function() {
 		assert.deepEqual(graph.lookup('ddd'), null);
 	});
-	
+
 	it('inserts nodes when not there yet', function() {
 		assert.deepEqual(graph.lookup('ddd'), null);
 		assert.deepEqual(graph.lookupOrInsertNode('ddd').data, 'ddd');
-		assert.deepEqual(graph.lookup('ddd').data, 'ddd');
+		assert.deepEqual(graph.lookup('ddd')!.data, 'ddd');
 	});
-	
+
 	it('can remove nodes', function() {
 		assert.deepEqual(graph.lookup('ddd'), null);
 		assert.deepEqual(graph.lookupOrInsertNode('ddd').data, 'ddd');
 		graph.removeNode('ddd');
 		assert.deepEqual(graph.lookup('ddd'), null);
 	});
-	
+
 	it('traverse from leaf', function() {
 		graph.inertEdge('foo', 'bar');
 		graph.traverse('bar', true, (node) => assert.equal(node, 'bar'));
 		var items = ['bar', 'foo'];
 		graph.traverse('bar', false, (node) => assert.equal(node, items.shift()));
 	});
-	
+
 	it('traverse from center', function() {
 		graph.inertEdge('1', '3');
 		graph.inertEdge('2', '3');
 		graph.inertEdge('3', '4');
 		graph.inertEdge('3', '5');
-		
+
 		var items = ['3', '4', '5'];
 		graph.traverse('3', true, (node) => assert.equal(node, items.shift()));
-		
+
 		var items = ['3', '1', '2'];
 		graph.traverse('3', false, (node) => assert.equal(node, items.shift()));
 	});
-	
+
 	it('traverse a chain', function() {
 		graph.inertEdge('1', '2');
 		graph.inertEdge('2', '3');
 		graph.inertEdge('3', '4');
 		graph.inertEdge('4', '5');
-		
+
 		var items = ['1', '2', '3', '4', '5'];
 		graph.traverse('1', true, (node) => assert.equal(node, items.shift()));
-		
+
 		var items = ['1', '2', '3', '4', '5'].reverse();
 		graph.traverse('5', false, (node) => assert.equal(node, items.shift()));
 	});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,9 @@
 'use strict';
-import * as path from "path";
-
 export module collections {
 
     var hasOwnProperty = Object.prototype.hasOwnProperty;
 
-    export function lookup<T>(collection: { [keys: string]: T }, key: string): T {
+    export function lookup<T>(collection: { [keys: string]: T }, key: string): T | null {
         if (hasOwnProperty.call(collection, key)) {
             return collection[key];
         }
@@ -74,7 +72,7 @@ export module strings {
     export function format(value: string, ...rest: any[]): string {
         return value.replace(/({\d+})/g, function (match) {
             var index = match.substring(1, match.length - 1);
-            return rest[index] || match;
+            return rest[+index] || match;
         });
     }
 
@@ -157,7 +155,7 @@ export module graph {
             return node;
         }
 
-        public lookup(data: T): Node<T> {
+        public lookup(data: T): Node<T> | null {
             return collections.lookup(this._nodes, this._hashFn(data));
         }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,11 @@
             "es2015.promise",
             "es2015.collection"
         ],
-        "types": ["node", "mocha", "chai"]
+        "types": ["node", "mocha", "chai"],
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Also stop using lambdas in the gulpfile - it's not downleveled, so it was unusable in lower versions of node. Included a polyfill for `Object.assign` for the same reason (and patched that by hand directly into the `lib` copy).

I've also discovered an issue with newlines in the baselines: Sourcemap baselines seem to always get emitted with the system newline. (Which makes tests fail on some platforms) I'm unsure what the correct fix is.
